### PR TITLE
fix(ci): harden Python runtime images

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,6 +1,8 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
-RUN apt-get update && apt-get install -y locales \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends locales \
     && echo "es_ES.UTF-8 UTF-8" > /etc/locale.gen \
     && echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
@@ -8,7 +10,9 @@ RUN apt-get update && apt-get install -y locales \
     && locale-gen de_DE.UTF-8 \
     && locale-gen en_US.UTF-8 \
     && dpkg-reconfigure --frontend=noninteractive locales \
-    && /usr/sbin/update-locale LANG=en_US.UTF-8
+    && /usr/sbin/update-locale LANG=en_US.UTF-8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG es_ES.UTF-8
 ENV LC_ALL es_ES.UTF-8
@@ -19,6 +23,12 @@ COPY . .
 
 ENV PYTHONPATH="/app"
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt \
+    && python -m pip uninstall -y pip setuptools wheel \
+    && addgroup --gid 10001 --system app \
+    && adduser --uid 10001 --gid 10001 --system --home /app app \
+    && chown -R app:app /app
+
+USER app
 
 CMD ["python", "src/main.py"]

--- a/forecast-back/Dockerfile
+++ b/forecast-back/Dockerfile
@@ -1,25 +1,33 @@
-FROM mirror.gcr.io/library/python:3.11-slim AS builder
-
-RUN pip install --upgrade pip
+FROM python:3.11-slim-bookworm AS builder
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir --prefix=/install -r requirements.txt
 
-FROM gcr.io/distroless/python3-debian12:nonroot
-ARG PYTHON_VERSION=3.11
+FROM python:3.11-slim-bookworm
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && addgroup --gid 10001 --system app \
+    && adduser --uid 10001 --gid 10001 --system --home /app app
 
 ENV PYTHONUNBUFFERED 1
 
-COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
-COPY --from=builder /usr/local/bin/uvicorn /app/uvicorn
+COPY --from=builder /install /usr/local
 
-COPY . /app
+COPY --chown=app:app . /app
 WORKDIR /app
 
 EXPOSE 8000
 
-ENV PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 
-CMD ["/app/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-ENV PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages
+RUN python -m pip uninstall -y pip setuptools wheel \
+    && chown -R app:app /app
+
+USER app
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/forecast-back/requirements.txt
+++ b/forecast-back/requirements.txt
@@ -1,2 +1,2 @@
-fastapi~=0.110.1
-uvicorn==0.20.0
+fastapi>=0.116.2,<0.117
+uvicorn>=0.35.0,<0.36


### PR DESCRIPTION
The universal Tekton image gate found fixed vulnerabilities in the distroless Python runtime and old FastAPI stack.

- use updated Debian Bookworm Python runtime layers and apply security upgrades
- install dependencies in a builder prefix and remove pip/setuptools/wheel from runtime
- run both Python services as UID/GID 10001
- update forecast FastAPI/Uvicorn to patched compatible releases

The Kubernetes contract, ports and application paths remain unchanged.