### PR TITLE
fix(front): write nginx pid to writable runtime volume

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,6 +1,8 @@
 # Set the worker processes to the number of CPU cores
 worker_processes auto;
-#pid /home/nginx/nginx.pid;
+# Chainguard runs as non-root and the Helm chart mounts /run/nginx as a
+# writable tmpfs. Keep the PID file there instead of the read-only /run root.
+pid /run/nginx/nginx.pid;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
The Chainguard nginx image runs non-root. The current config leaves nginx on its default /run/nginx.pid, but the platform mounts only /run/nginx as writable tmpfs.

Set the pid path explicitly to /run/nginx/nginx.pid so the immutable front image starts cleanly in PRE/PRO. No visual or routing behavior changes.